### PR TITLE
Gui grid

### DIFF
--- a/life/Cargo.lock
+++ b/life/Cargo.lock
@@ -3,5 +3,339 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
+
+[[package]]
+name = "ahash"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
+name = "autocfg"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bytemuck"
+version = "1.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6b1fc10dbac614ebc03540c9dbd60e83887fda27794998c6528f1782047d540"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "color_quant"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
+
+[[package]]
+name = "crc32fast"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "fdeflate"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
+name = "flate2"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11faaf5a5236997af9848be0bef4db95824b1d534ebc64d0f0c6cf3e67bd38dc"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "fontdue"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0793f5137567643cf65ea42043a538804ff0fbf288649e2141442b602d81f9bc"
+dependencies = [
+ "hashbrown",
+ "ttf-parser",
+]
+
+[[package]]
+name = "glam"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e05e7e6723e3455f4818c7b26e855439f7546cf617ef669d1adedb8669e5cb9"
+
+[[package]]
+name = "hashbrown"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "image"
+version = "0.24.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5690139d2f55868e080017335e4b94cb7414274c74f1669c84fb5feba2c9f69d"
+dependencies = [
+ "bytemuck",
+ "byteorder",
+ "color_quant",
+ "num-traits",
+ "png",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.171"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
+
+[[package]]
 name = "life"
 version = "0.1.0"
+dependencies = [
+ "macroquad",
+]
+
+[[package]]
+name = "macroquad"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81fef16b2d4de22ac372b5d7d76273c0ead0a31f9de9bc649af8f816816db8a8"
+dependencies = [
+ "fontdue",
+ "glam",
+ "image",
+ "macroquad_macro",
+ "miniquad",
+ "quad-rand",
+ "slotmap",
+]
+
+[[package]]
+name = "macroquad_macro"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64b1d96218903768c1ce078b657c0d5965465c95a60d2682fd97443c9d2483dd"
+
+[[package]]
+name = "malloc_buf"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "miniquad"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2124e5e6bab86d96f263d78dc763c29e0da4c4f7ff0e1bb33f1d3905d1121262"
+dependencies = [
+ "libc",
+ "ndk-sys",
+ "objc",
+ "winapi",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e3e04debbb59698c15bacbb6d93584a8c0ca9cc3213cb423d31f760d8843ce5"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
+name = "ndk-sys"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1bcdd74c20ad5d95aacd60ef9ba40fdf77f767051040541df557b7a9b2a2121"
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "objc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
+dependencies = [
+ "malloc_buf",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d75b0bedcc4fe52caa0e03d9f1151a323e4aa5e2d78ba3580400cd3c9e2bc4bc"
+
+[[package]]
+name = "png"
+version = "0.17.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82151a2fc869e011c153adc57cf2789ccb8d9906ce52c0b39a6b5697749d7526"
+dependencies = [
+ "bitflags",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quad-rand"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a651516ddc9168ebd67b24afd085a718be02f8858fe406591b013d101ce2f40"
+
+[[package]]
+name = "quote"
+version = "1.0.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
+
+[[package]]
+name = "slotmap"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbff4acf519f630b3a3ddcfaea6c06b42174d9a44bc70c620e9ed1649d58b82a"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "ttf-parser"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b3e06c9b9d80ed6b745c7159c40b311ad2916abb34a49e9be2653b90db0d8dd"
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "zerocopy"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]

--- a/life/Cargo.toml
+++ b/life/Cargo.toml
@@ -4,3 +4,4 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+macroquad = "0.4"

--- a/life/src/main.rs
+++ b/life/src/main.rs
@@ -1,4 +1,4 @@
-use macroquad::{color::{BLUE, RED, WHITE}, shapes::draw_rectangle, window::{clear_background, next_frame, screen_height, screen_width}};
+use macroquad::{color::{BLUE, RED, WHITE}, shapes::draw_rectangle, window::{clear_background, next_frame, screen_height, screen_width, Conf}};
 
 const N: usize = 4;
 const M: usize = 4;
@@ -59,8 +59,17 @@ fn draw_cells_grid(cell_witdh: f32, cell_height: f32) {
     }
 }
 
+fn window_conf() -> Conf {
+    Conf {
+        window_title: "Game of Life".to_owned(),
+        window_width: 800,
+        window_height: 800,
+        ..Default::default()
+    }
+}
 
-#[macroquad::main("Game of Life")]
+
+#[macroquad::main(window_conf)]
 async fn main() {
     let mut matrix: [[u8; N]; N] = [
         [0,1,0,0],

--- a/life/src/main.rs
+++ b/life/src/main.rs
@@ -89,6 +89,13 @@ fn check_cell_alive_neighbours(col_i: usize, row_i: usize, matrix: &[[bool; N]; 
     alive_neighbours
 }
 
+/// Draws a rectangle for each cell in the matrix, forming the necessary grid on the screen
+/// 
+/// # Arguments
+/// 
+/// - `cell_witdh`: The width of a single cell of the matrix.
+/// - `cell_height`: The height of a single cell of the matrix.
+/// - `matrix`: An array with arrays that represent the matrix which contains every cell.
 fn draw_cells_grid(cell_witdh: f32, cell_height: f32, matrix: &[[bool; N]; N]) {
     for (row_i, row) in matrix.iter().enumerate() {
         let y = cell_height * row_i as f32;
@@ -100,6 +107,11 @@ fn draw_cells_grid(cell_witdh: f32, cell_height: f32, matrix: &[[bool; N]; N]) {
     }
 }
 
+/// Sets the configuration of the screen used.
+/// 
+/// # Returns
+/// 
+/// A struct `Conf` with the configuration needed
 fn window_conf() -> Conf {
     Conf {
         window_title: "Game of Life".to_owned(),
@@ -147,14 +159,16 @@ async fn main() {
         [false,true,false],
         [false,true,false],
     ];
+    // Calculation of cell dimensions so the whole screen is used.
     let cell_width = screen_width() / N as f32;
     let cell_height = screen_height() / M as f32;
-
+    // Used for updating each frame after a desired time
     let mut last_update = get_time();
     
     loop {
         clear_background(WHITE);
         draw_cells_grid(cell_width, cell_height, &matrix);
+        // After 2 seconds, the matrix is changed so it updates in the next frame
         if get_time() - last_update > 2. {
             last_update = get_time();
             let (cells_to_revive, cells_to_kill) = check_cell_state(&matrix);

--- a/life/src/main.rs
+++ b/life/src/main.rs
@@ -1,6 +1,6 @@
-use std::{thread::sleep, time::Duration};
+use macroquad::{color::{BLUE, RED, WHITE}, shapes::draw_rectangle, window::{clear_background, next_frame, screen_height, screen_width}};
 
-const N: usize = 3;
+const N: usize = 4;
 const OFFSETS: [i8; 3] = [-1, 0, 1];
 const DEAD: u8 = 0;
 const ALIVE: u8 = 1;
@@ -47,14 +47,33 @@ fn check_cell_alive_neighbours(col_i: usize, row_i: usize, matrix: [[u8; N]; N])
     alive_neighbours
 }
 
-fn main() {
+fn draw_cells_grid(cell_size: f32) {
+    for i in 0..N {
+        let y = cell_size * i as f32;
+        for j in 0..N {
+            let x = cell_size * j as f32;
+            let color = if (i + j) % 2 != 0 { RED } else { BLUE };
+            draw_rectangle(x, y, cell_size, cell_size, color);
+        }
+    }
+}
+
+
+#[macroquad::main("Game of Life")]
+async fn main() {
     let mut matrix: [[u8; N]; N] = [
-        [0,1,0],
-        [0,1,0],
-        [0,1,0],
+        [0,1,0,0],
+        [0,1,0,0],
+        [0,1,0,0],
+        [0,0,0,0],
         ];
-    
+
+    let game_size = screen_width().min(screen_height());    
+    let cell_size = game_size / N as f32;
     loop {
+        clear_background(WHITE);
+        draw_cells_grid(cell_size);
+
         let mut cells_to_revive: Vec<(usize, usize)> = Vec::new();
         let mut cells_to_kill: Vec<(usize, usize)> = Vec::new();
 
@@ -73,7 +92,7 @@ fn main() {
         manage_cell_state(cells_to_kill, DEAD, &mut matrix);
         manage_cell_state(cells_to_revive, ALIVE, &mut matrix);
 
-        sleep(Duration::from_secs(5));
+        next_frame().await;
     }
 
 }

--- a/life/src/main.rs
+++ b/life/src/main.rs
@@ -1,6 +1,7 @@
 use macroquad::{color::{BLUE, RED, WHITE}, shapes::draw_rectangle, window::{clear_background, next_frame, screen_height, screen_width}};
 
 const N: usize = 4;
+const M: usize = 4;
 const OFFSETS: [i8; 3] = [-1, 0, 1];
 const DEAD: u8 = 0;
 const ALIVE: u8 = 1;
@@ -47,13 +48,13 @@ fn check_cell_alive_neighbours(col_i: usize, row_i: usize, matrix: [[u8; N]; N])
     alive_neighbours
 }
 
-fn draw_cells_grid(cell_size: f32) {
-    for i in 0..N {
-        let y = cell_size * i as f32;
+fn draw_cells_grid(cell_witdh: f32, cell_height: f32) {
+    for i in 0..M {
+        let y = cell_height * i as f32;
         for j in 0..N {
-            let x = cell_size * j as f32;
+            let x = cell_witdh * j as f32;
             let color = if (i + j) % 2 != 0 { RED } else { BLUE };
-            draw_rectangle(x, y, cell_size, cell_size, color);
+            draw_rectangle(x, y, cell_witdh, cell_height, color);
         }
     }
 }
@@ -68,11 +69,12 @@ async fn main() {
         [0,0,0,0],
         ];
 
-    let game_size = screen_width().min(screen_height());    
-    let cell_size = game_size / N as f32;
+    // let game_size = screen_width().min(screen_height());    
+    let cell_width = screen_width() / N as f32;
+    let cell_height = screen_height() / M as f32;
     loop {
         clear_background(WHITE);
-        draw_cells_grid(cell_size);
+        draw_cells_grid(cell_width, cell_height);
 
         let mut cells_to_revive: Vec<(usize, usize)> = Vec::new();
         let mut cells_to_kill: Vec<(usize, usize)> = Vec::new();


### PR DESCRIPTION
Simple implementation of the grid used to show the cells that are alive and dead. The grid is formed with different rectangles in a squared screen, all done with macroquad. Each frame lasts 2 second.
Already merged with the game functionality, this allows us to have an almost finished MVP where we can watch a hardcoded pattern on the screen.
In the future, new modules need to be created to have UI things on one module and game logic on another module.